### PR TITLE
Add MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include requirements.txt
+include README.md
+include COPYING
+recursive-include test *.py


### PR DESCRIPTION
There are a handful of files that should be in the source distribution
by default, but aren't picked up automatically. In particular,
requirements.txt is missed, which is the cause of CCI-MOC/haas#316.